### PR TITLE
fix: teleport tile highlighting and crystal tile highlighting

### DIFF
--- a/src/classes/board.ts
+++ b/src/classes/board.ts
@@ -161,7 +161,11 @@ export class Board {
     // Teleporting tile
     if (hero.getTile().tileType === ETiles.TELEPORTER) {
       const teleportTiles: Tile[] = this.tiles.filter(tile => tile.tileType === ETiles.TELEPORTER);
-      this.highlightTiles(teleportTiles);
+      teleportTiles.forEach(tile => {
+        if (!tile.hero) {
+          this.highlightTiles([tile]);
+        }
+      });
     }
 
     // Ninja teleporting
@@ -256,7 +260,8 @@ export class Board {
         if (
           rangeType === ERange.MOVE &&
           !isEnemySpawn(this.context, tile) &&
-          (!tile.hero || tile.hero.isKO)
+          (!tile.hero || tile.hero.isKO) &&
+          !tile.crystal
         )  inRangeTiles.add(tile);
 
         if (rangeType === ERange.ATTACK || rangeType === ERange.HEAL) {


### PR DESCRIPTION
you could teleport via teleport tile on top of a hero. tiles with crystals would also be highlighted. This fixes these.