### PR TITLE
fix: Apply paladin aura to currentPower instead of Base power

### DIFF
--- a/src/classes/factions/hero.ts
+++ b/src/classes/factions/hero.ts
@@ -184,9 +184,9 @@ export abstract class Hero extends Phaser.GameObjects.Container {
     const attackTileBuff = this.stats.attackTile ? attackTileDamage : 0;
     const superCharge = this.stats.superCharge ? 3 : 1;
     const priestessDebuff = this.stats.priestessDebuff ? 0.5 : 1;
-    const paladinAura = this.stats.paladinAura > 0 ? this.stats.paladinAura * 0.05 * this.stats.basePower : 0;
+    const paladinAura = (this.stats.paladinAura * 0.05) + 1;
 
-    return roundToFive((this.stats.basePower + attackTileBuff) * rangeModifier * superCharge * priestessDebuff * runeMetalBuff) + paladinAura;
+    return roundToFive(this.stats.basePower + attackTileBuff) * rangeModifier * superCharge * priestessDebuff * runeMetalBuff * paladinAura;
   }
 
   getPhysicalDamageResistance(): number {


### PR DESCRIPTION
In the original HA the Paladins aura would count up total number of auras, multiply by 5%, then add that percent more damage. If there is 1 paladin then the unit receives +5%, 2 would be +10%, and 3 would be +15%

HA does +5% per paladin on the **total attack damage** - meanwhile FA is doing +5% per paladin on the **base attack damage**.
This PR adjusts FA to be in parity with HA.
An example:
An engineer deals 200 damage as their base. On a sword tile they deal 340 damage. Currently in fan academy paladins aura ups that to 310 (5% of 200 is 10), however it should be 315 (5% of 340 is 17, rounded to 5s is 15).
When combined with other effects (eg. scroll, power/sword tile, heretic debuffs, etc.) this can make quite a difference.


verification this is how it works in the original via screenshots in challenges in original HA:
Without paladin:
<img width="479" height="453" alt="Screenshot_2026-04-08_19-19-29" src="https://github.com/user-attachments/assets/5ce77fdc-d144-40ea-a2ce-d5b4a7352884" />
With Paladin:
<img width="421" height="447" alt="Screenshot_2026-04-08_19-23-47" src="https://github.com/user-attachments/assets/003c8029-871f-4d53-9e1b-dc2c9e90ea04" />